### PR TITLE
feat!: drop Node.js v20 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "20 || 22 || >=24"
+    "node": "22 || >=24"
   },
   "scripts": {
     "coverage": "nyc npm test",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v20 is no longer supported.